### PR TITLE
Added level display when battles start

### DIFF
--- a/handlers/challenge-handler.go
+++ b/handlers/challenge-handler.go
@@ -23,9 +23,11 @@ func (h *Challenge) sendInitialPkmnMessage(ctx context.Context, t *basicTrainerD
 	initialPokemonTemplInfo := struct {
 		TrainerName string
 		PokemonName string
+		Level       int
 	}{
 		TrainerName: t.trainer.GetTrainer().Name,
-		PokemonName: t.pkmn[0].GetPokemon().Name}
+		PokemonName: t.pkmn[0].GetPokemon().Name,
+		Level:       t.pkmn[0].GetPokemon().Level}
 	return messaging.SendTempl(client, t.lastContactURL, messaging.TemplMessage{
 		Public:    true,
 		Image:     t.pkmn[0].GetPokemon().SpriteURL,

--- a/handlers/templates.go
+++ b/handlers/templates.go
@@ -328,12 +328,12 @@ var moveReportTemplate *template.Template
 
 var switchPokemonTemplateText = `
 {{ .Switcher }} has withdrawn {{ .WithdrawnPokemon }}.
-{{ .Switcher }} sent out {{ .SelectedPokemon }}!
+{{ .Switcher }} sent out {{ .SelectedPokemon }}! (Lv. {{ .SelectedLevel }})
 `
 var switchPokemonTemplate *template.Template
 
 var initialPokemonSendOutTemplateText = `
-{{ .TrainerName }} sent out {{ .PokemonName }}!
+{{ .TrainerName }} sent out {{ .PokemonName }}! (Lv. {{ .Level }})
 `
 var initialPokemonSendOutTemplate *template.Template
 
@@ -348,7 +348,7 @@ var trainerLostTemplateText = `
 var trainerLostTemplate *template.Template
 
 var wildBattleStartedTemplateText = `
-A wild {{ .WildPokemonName }} appeared!
+A wild {{ .WildPokemonName }} appeared! (Lv. {{ .Level }})
 `
 var wildBattleStartedTemplate *template.Template
 

--- a/handlers/wild-encounters.go
+++ b/handlers/wild-encounters.go
@@ -84,8 +84,10 @@ func (h *WildEncounter) runTask(ctx context.Context, s Services) error {
 	// Send message telling the trainer that an encounter happened
 	templInfo := struct {
 		WildPokemonName string
+		Level           int
 	}{
-		WildPokemonName: wild.GetPokemon().Name}
+		WildPokemonName: wild.GetPokemon().Name,
+		Level:           wild.GetPokemon().Level}
 	err = messaging.SendTempl(client, requester.lastContactURL, messaging.TemplMessage{
 		Templ:     wildBattleStartedTemplate,
 		TemplInfo: templInfo,


### PR DESCRIPTION
Now the Pokemon's levels are shown at the start of a trainer and wild battle.

Resolves #26.
