### PR TITLE
Fix self-targetting status moves without accuracy not working

### DIFF
--- a/handlers/templates.go
+++ b/handlers/templates.go
@@ -322,7 +322,7 @@ The move had no effect...
 {{ .TargetActionPrefix }} {{ .TargetPokemonName }} has been burned!
 {{ else -}}
 {{- end -}}
-{{ printf "\u0060" }}{{ printf "%-15s" .TargetPokemonName }}: {{ .UserHPBar }}{{ printf "\u0060" }}
+{{ printf "\u0060" }}{{ printf "%-15s" .TargetPokemonName }}: {{ .TargetHPBar }}{{ printf "\u0060" }}
 `
 var moveReportTemplate *template.Template
 

--- a/handlers/turn-processing.go
+++ b/handlers/turn-processing.go
@@ -108,17 +108,23 @@ func (tp *turnProcessor) runMove(ctx context.Context, public bool, user, target 
 		return false, handlerError{user: "could not run move", err: err}
 	}
 
+	// The caller always assumes that the target is the opponent, but sometimes
+	// it's the same as the user. Correct it if that's the case.
+	if move.Target == pkmn.SelfMoveTarget {
+		target = user
+	}
+
 	// Each action in the template prefaces itself with the name of the Pokemon
 	// in question. For instance, "the wild bulbsaur used tackle" or
 	// "ash.ketchum's pikachu is poisoned!". We need to figuire out which of
 	// these prefixes is appopriate for each Pokemon
 	userActionPrefix := user.trainer.GetTrainer().Name + "'s"
 	if user.trainer.GetTrainer().Type == pkmn.WildTrainerType {
-		userActionPrefix = "The wild "
+		userActionPrefix = "The wild"
 	}
 	targetActionPrefix := target.trainer.GetTrainer().Name + "'s"
 	if target.trainer.GetTrainer().Type == pkmn.WildTrainerType {
-		targetActionPrefix = "The wild "
+		targetActionPrefix = "The wild"
 	}
 
 	// Send the move report
@@ -126,7 +132,7 @@ func (tp *turnProcessor) runMove(ctx context.Context, public bool, user, target 
 		pkmn.MoveReport
 		UserActionPrefix   string
 		UserPokemonName    string
-		UserHPBar          string
+		TargetHPBar        string
 		TargetActionPrefix string
 		TargetPokemonName  string
 		MoveName           string
@@ -134,7 +140,7 @@ func (tp *turnProcessor) runMove(ctx context.Context, public bool, user, target 
 		MoveReport:         mr,
 		UserActionPrefix:   userActionPrefix,
 		UserPokemonName:    user.activePkmn().GetPokemon().Name,
-		UserHPBar:          makeTextHPBar(target.activePkmn().GetPokemon(), target.activePkmnBattleInfo().GetPokemonBattleInfo()),
+		TargetHPBar:        makeTextHPBar(target.activePkmn().GetPokemon(), target.activePkmnBattleInfo().GetPokemonBattleInfo()),
 		TargetActionPrefix: targetActionPrefix,
 		TargetPokemonName:  target.activePkmn().GetPokemon().Name,
 		MoveName:           move.Name}

--- a/pkmn/move.go
+++ b/pkmn/move.go
@@ -209,10 +209,16 @@ func calcDamage(user, target *Pokemon, userBI, targetBI *PokemonBattleInfo, move
 func RunMove(user, target *Pokemon, userBI, targetBI *PokemonBattleInfo, move Move) (MoveReport, error) {
 	var mr MoveReport
 
-	if rand.Intn(100)+1 > move.Accuracy*(CalcIBAccuracy(*user, *userBI)/CalcIBEvasion(*target, *targetBI)) {
-		// The move missed, so we have nothing to do
-		mr.Missed = true
-		return mr, nil
+	// Moves with zero accuracy always hit, so no further calculation is needed
+	// in that case.
+	if move.Accuracy != 0 {
+		if rand.Intn(100)+1 > move.Accuracy*(CalcIBAccuracy(*user, *userBI)/CalcIBEvasion(*target, *targetBI)) {
+			// The move missed, so we have nothing to do
+			mr.Missed = true
+			// We don't care about effectiveness since the move missed
+			mr.Effectiveness = 1.0
+			return mr, nil
+		}
 	}
 
 	// Check if the move targets the user


### PR DESCRIPTION
Now, moves like harden that target the user and cannot miss will display their effects correctly.

I accidentally put this on the wrong branch, but nobody's looking, right? Probably not a single other person will see this pull request. Email me if you do.

Resolves #31.
